### PR TITLE
Add functions for building register params

### DIFF
--- a/django_restful_admin/__init__.py
+++ b/django_restful_admin/__init__.py
@@ -1,2 +1,2 @@
-from .models import site, RestFulModelAdmin
+from .models import site, RestFulModelAdmin, RestFulAdminSite
 

--- a/django_restful_admin/models.py
+++ b/django_restful_admin/models.py
@@ -138,6 +138,12 @@ class RestFulAdminSite:
         """
         return model in self._registry
 
+    def get_model_basename(self, model):
+        return None
+
+    def get_model_url(self, model):
+        return '%s/%s' % (model._meta.app_label, model._meta.model_name)
+
     def get_urls(self):
         router = DefaultRouter()
         view_sets = []
@@ -154,7 +160,7 @@ class RestFulAdminSite:
                 view_set.serializer_class = serializer_class
 
             view_sets.append(view_set)
-            router.register('%s/%s' % (model._meta.app_label, model._meta.model_name), view_set)
+            router.register(self.get_model_url(model), view_set, self.get_model_basename(model))
 
         return router.urls + self._url_patterns
 


### PR DESCRIPTION
Move code from `RestFulAdminSite.register` to `get_model_url` to build the url, and add the [`basename`](https://www.django-rest-framework.org/api-guide/routers/#usage) parameter to the [`DefaultRouter`](https://www.django-rest-framework.org/api-guide/routers/#defaultrouter) `register` method via a new function `get_model_basename` (returning `None` by default to keep backward compatibility).

This allows anyone to extend these functions by subclassing `RestFulAdminSite`.

In my case, I would like to customise the `get_model_basename` using something similar to `get_model_url`:
```python
    def get_model_basename(self, model):
        return '%s-%s' % (model._meta.app_label, model._meta.model_name)
```

Which can be done by extending `RestFulAdminSite`:
```python
from django_restful_admin import RestFulAdminSite

class CustomRestFulAdminSite(RestFulAdminSite):
    def get_model_basename(self, model):
        return '%s-%s' % (model._meta.app_label, model._meta.model_name)

site = CustomRestFulAdminSite()

site.register(MyModel)
```