### PR TITLE
Add option to set default view class

### DIFF
--- a/django_restful_admin/__init__.py
+++ b/django_restful_admin/__init__.py
@@ -1,2 +1,2 @@
-from .models import site, RestFulModelAdmin
+from .models import site, RestFulModelAdmin, RestFulAdminSite
 

--- a/django_restful_admin/models.py
+++ b/django_restful_admin/models.py
@@ -63,13 +63,14 @@ class BaseModelSerializer(ModelSerializer):
 
 
 class RestFulAdminSite:
-    def __init__(self):
+    def __init__(self, view_class=RestFulModelAdmin):
         self._registry = {}
         self._url_patterns = []
+        self.default_view_class = view_class
 
     def register(self, model_or_iterable, view_class=None, **options):
         if not view_class:
-            view_class = RestFulModelAdmin
+            view_class = self.default_view_class
 
         if isinstance(model_or_iterable, ModelBase):
             model_or_iterable = [model_or_iterable]


### PR DESCRIPTION
Just a little tweak, instead of having to add the `view_class` attribute in `register` for all the models, with a new `default_view_class` option on the `RestFulAdminSite` constructor we can set the default `view_class` once:
```python
from django_restful_admin import RestFulModelAdmin, RestFulAdminSite

class CustomRestAdmin(RestFulModelAdmin):
    # custom props go here, for instance:
    # pagination_class = PageNumberPagination
    pass

site = RestFulAdminSite(view_class=CustomRestAdmin)

# and later on use `register` without arguments for all model classes:
site.register(MyModel)
```

My use case is setting my own `CustomRestAdmin` to override the default pagination, and that needs to apply to all of the endpoints generated using `django_restful_admin` 