### PR TITLE
fix delete method

### DIFF
--- a/django_restful_admin/admin.py
+++ b/django_restful_admin/admin.py
@@ -34,7 +34,7 @@ class AuthPermissionViewSetMixin:
             'create': self._make_permission_key('add'),
             'update': self._make_permission_key('change'),
             'partial_update': self._make_permission_key('change'),
-            'delete': self._make_permission_key('delete'),
+            'destroy': self._make_permission_key('delete'),
         }
         permission_map.update(self.permission_map)
         return permission_map
@@ -161,7 +161,7 @@ class RestFulModelAdmin(AuthPermissionViewSetMixin, viewsets.ModelViewSet):
             'create': self._make_permission_key('add'),
             'update': self._make_permission_key('change'),
             'partial_update': self._make_permission_key('change'),
-            'delete': self._make_permission_key('delete'),
+            'destroy': self._make_permission_key('delete'),
         }
         permission_map.update(self.permission_map)
         return permission_map


### PR DESCRIPTION
Issue #12 

Resolved an issue in the get_permission_map method where the mapping for the 'delete' method was inconsistent with the actual method name used in the code. The discrepancy was identified in the delete method, which was implemented as 'destroy.' To address this, I've updated the get_permission_map function to correctly map to the 'destroy' method. This adjustment ensures that the mapping aligns with the actual method names, resolving the bug and improving code consistency.

